### PR TITLE
Added integration with "EE for Starbound"

### DIFF
--- a/EES_transmutationstudylist.config.patch
+++ b/EES_transmutationstudylist.config.patch
@@ -1,0 +1,35 @@
+[
+    // Farm - T1 - Aegi
+    { "op": "add", "path": "/farm/T1/ambrumfiber", "value": true},
+    { "op": "add", "path": "/farm/T1/borato", "value": true},
+    { "op": "add", "path": "/farm/T1/selvasextract", "value": true},
+    { "op": "add", "path": "/farm/T1/loftgrain", "value": true},
+    { "op": "add", "path": "/farm/T1/mellowroot", "value": true},
+    { "op": "add", "path": "/farm/T1/vahlberries", "value": true},
+
+    // Farm - T1 - Avikan
+    { "op": "add", "path": "/farm/T1/avikanspices", "value": true},
+    { "op": "add", "path": "/farm/T1/bolbohn", "value": true},
+    { "op": "add", "path": "/farm/T1/dunestalk", "value": true},
+    { "op": "add", "path": "/farm/T1/kadavancactus", "value": true},
+
+    // Hunt - T1 - Aegi
+    { "op": "add", "path": "/hunt/T1/farythscale", "value": true},
+    { "op": "add", "path": "/hunt/T1/kelbethide", "value": true},
+
+    // Hunt - T1 - Avikan
+    { "op": "add", "path": "/hunt/T1/monsterbone", "value": true},
+    { "op": "add", "path": "/hunt/T1/monsterhide", "value": true},
+    { "op": "add", "path": "/hunt/T1/monsterscales", "value": true},
+    { "op": "add", "path": "/hunt/T1/sandcrawlermeat", "value": true},
+    { "op": "add", "path": "/hunt/T1/sandcrawlertooth", "value": true},
+    { "op": "add", "path": "/hunt/T1/valahrgland", "value": true},
+
+    // Hunt - T2 - Avikan
+    { "op": "add", "path": "/hunt/T1/monsterclaws", "value": true},
+    { "op": "add", "path": "/hunt/T1/monsterplate", "value": true},
+
+    // Hunt - T3 - Avikan
+    { "op": "add", "path": "/hunt/T1/greatmonsterbone", "value": true},
+    { "op": "add", "path": "/hunt/T1/monsterspine", "value": true}
+]

--- a/EES_transmutationstudylist.config.patch
+++ b/EES_transmutationstudylist.config.patch
@@ -26,10 +26,10 @@
     { "op": "add", "path": "/hunt/T1/valahrgland", "value": true},
 
     // Hunt - T2 - Avikan
-    { "op": "add", "path": "/hunt/T1/monsterclaws", "value": true},
-    { "op": "add", "path": "/hunt/T1/monsterplate", "value": true},
+    { "op": "add", "path": "/hunt/T2/monsterclaws", "value": true},
+    { "op": "add", "path": "/hunt/T2/monsterplate", "value": true},
 
     // Hunt - T3 - Avikan
-    { "op": "add", "path": "/hunt/T1/greatmonsterbone", "value": true},
-    { "op": "add", "path": "/hunt/T1/monsterspine", "value": true}
+    { "op": "add", "path": "/hunt/T3/greatmonsterbone", "value": true},
+    { "op": "add", "path": "/hunt/T3/monsterspine", "value": true}
 ]


### PR DESCRIPTION
Hello!

I'm the author of **"Equivalent Exchange For Starbound"** ([Steam](https://steamcommunity.com/sharedfiles/filedetails/?id=1790667104), [GitHub](https://github.com/AlbertoRota/EquivalentExchangeForStarbound), [ChucklefishForums](https://community.playstarbound.com/resources/equivalent-exchange-for-starbound.5780/)), a mod targeted to reduce the amount of grind in the medium/late game while keeping the "exploration" and "crafting" relevant during the whole gameplay.

Up until now, I handled the integration between your mod (A mod that I'm enjoying a lot) with mine on my side.
To simplify this on my side, and because no one knows your mod better than you, here you have a "pull request" to switch this to your mod.

This way you have full control over _what_, _where_ and _when_ the integration will take place.
Also, since you know your mod better than I'll never do, for you will be a breeze to keet the list updated with your latest developments.

If you have any doubt, I've created the following thread in Steam to try explain how this file works:
[Tutorial: How to add support between your mod and this one.](https://steamcommunity.com/workshop/filedetails/discussion/1790667104/1642042464747956675/)

Regards!