### PR TITLE
changed Throwable to vanilla's throwableItem

### DIFF
--- a/items/active/weapons/activethrowables/akkimari-nailbomb/akkimari-nailbomb.activeitem
+++ b/items/active/weapons/activethrowables/akkimari-nailbomb/akkimari-nailbomb.activeitem
@@ -7,7 +7,7 @@
   "shortdescription" : "Makeshift Nailbomb",
   "level" : 1,
   "tooltipKind" : "thea-activethrowable",
-  "category" : "Throwable",
+  "category" : "throwableItem",
   "itemTags" : ["throwableweapon","akkimari"],
   "twoHanded" : false,
 

--- a/items/active/weapons/activethrowables/akkimari-throwingknife/akkimari-throwingknife.activeitem
+++ b/items/active/weapons/activethrowables/akkimari-throwingknife/akkimari-throwingknife.activeitem
@@ -7,7 +7,7 @@
   "shortdescription" : "Makeshift Throwing Knives",
   "level" : 1,
   "tooltipKind" : "thea-activethrowable",
-  "category" : "Throwable",
+  "category" : "throwableItem",
   "itemTags" : ["throwableweapon","akkimari"],
   "twoHanded" : false,
 

--- a/items/active/weapons/activethrowables/akkimari-vaashbomb/akkimari-vaashbomb.activeitem
+++ b/items/active/weapons/activethrowables/akkimari-vaashbomb/akkimari-vaashbomb.activeitem
@@ -7,7 +7,7 @@
   "shortdescription" : "Akris Vaash Bomb",
   "level" : 1,
   "tooltipKind" : "thea-activethrowable",
-  "category" : "Throwable",
+  "category" : "throwableItem",
   "itemTags" : ["throwableweapon","akkimari"],
   "twoHanded" : false,
 

--- a/items/active/weapons/activethrowables/allianceexplosivecharge/allianceexplosivecharge.activeitem
+++ b/items/active/weapons/activethrowables/allianceexplosivecharge/allianceexplosivecharge.activeitem
@@ -7,7 +7,7 @@
   "shortdescription" : "Alliance Explosive Charge",
   "level" : 1,
   "tooltipKind" : "thea-activethrowable",
-  "category" : "Throwable",
+  "category" : "throwableItem",
   "itemTags" : ["throwableweapon","alliance"],
   "twoHanded" : false,
 

--- a/items/active/weapons/activethrowables/alliancethrowablegrenade/alliancethrowablegrenade.activeitem
+++ b/items/active/weapons/activethrowables/alliancethrowablegrenade/alliancethrowablegrenade.activeitem
@@ -7,7 +7,7 @@
   "shortdescription" : "Type 2 Grenade",
   "level" : 1,
   "tooltipKind" : "thea-activethrowable",
-  "category" : "Throwable",
+  "category" : "throwableItem",
   "itemTags" : ["throwableweapon","alliance"],
   "twoHanded" : false,
 

--- a/items/active/weapons/activethrowables/avikanexplosive/avikanexplosive.activeitem
+++ b/items/active/weapons/activethrowables/avikanexplosive/avikanexplosive.activeitem
@@ -7,7 +7,7 @@
   "shortdescription" : "Vanguard Explosive Charge",
   "level" : 1,
   "tooltipKind" : "thea-activethrowable",
-  "category" : "Throwable",
+  "category" : "throwableItem",
   "itemTags" : ["throwableweapon","avikan"],
   "twoHanded" : false,
 

--- a/items/active/weapons/activethrowables/avikanjavelin/avikanjavelin.activeitem
+++ b/items/active/weapons/activethrowables/avikanjavelin/avikanjavelin.activeitem
@@ -7,7 +7,7 @@
   "shortdescription" : "Bone Javelin",
   "level" : 1,
   "tooltipKind" : "thea-activethrowable",
-  "category" : "Throwable",
+  "category" : "throwableItem",
   "itemTags" : ["throwableweapon","akkimari"],
   "twoHanded" : false,
 

--- a/items/active/weapons/activethrowables/avikanjavelin2/avikanjavelin2.activeitem
+++ b/items/active/weapons/activethrowables/avikanjavelin2/avikanjavelin2.activeitem
@@ -7,7 +7,7 @@
   "shortdescription" : "Hunter's Javelin",
   "level" : 1,
   "tooltipKind" : "thea-activethrowable",
-  "category" : "Throwable",
+  "category" : "throwableItem",
   "itemTags" : ["throwableweapon","akkimari"],
   "twoHanded" : false,
 

--- a/items/active/weapons/activethrowables/avikanpoisonspiketrap/avikanpoisonspiketrap.activeitem
+++ b/items/active/weapons/activethrowables/avikanpoisonspiketrap/avikanpoisonspiketrap.activeitem
@@ -7,7 +7,7 @@
   "shortdescription" : "Poisoned Bone Spikes",
   "level" : 1,
   "tooltipKind" : "thea-activethrowable",
-  "category" : "Throwable",
+  "category" : "throwableItem",
   "itemTags" : ["throwableweapon","trink"],
   "twoHanded" : false,
 

--- a/items/active/weapons/activethrowables/avikansandbomb/avikansandbomb.activeitem
+++ b/items/active/weapons/activethrowables/avikansandbomb/avikansandbomb.activeitem
@@ -7,7 +7,7 @@
   "shortdescription" : "Sand Bomb",
   "level" : 1,
   "tooltipKind" : "thea-activethrowable",
-  "category" : "Throwable",
+  "category" : "throwableItem",
   "itemTags" : ["throwableweapon","avikan"],
   "twoHanded" : false,
 

--- a/items/active/weapons/activethrowables/avikanspiketrap/avikanspiketrap.activeitem
+++ b/items/active/weapons/activethrowables/avikanspiketrap/avikanspiketrap.activeitem
@@ -7,7 +7,7 @@
   "shortdescription" : "Bone Spikes",
   "level" : 1,
   "tooltipKind" : "thea-activethrowable",
-  "category" : "Throwable",
+  "category" : "throwableItem",
   "itemTags" : ["throwableweapon","trink"],
   "twoHanded" : false,
 

--- a/items/active/weapons/activethrowables/avikantarspiketrap/avikantarspiketrap.activeitem
+++ b/items/active/weapons/activethrowables/avikantarspiketrap/avikantarspiketrap.activeitem
@@ -7,7 +7,7 @@
   "shortdescription" : "Tarred Bone Spikes",
   "level" : 1,
   "tooltipKind" : "thea-activethrowable",
-  "category" : "Throwable",
+  "category" : "throwableItem",
   "itemTags" : ["throwableweapon","trink"],
   "twoHanded" : false,
 

--- a/items/active/weapons/activethrowables/avikanthrowablegrenade/avikanthrowablegrenade.activeitem
+++ b/items/active/weapons/activethrowables/avikanthrowablegrenade/avikanthrowablegrenade.activeitem
@@ -7,7 +7,7 @@
   "shortdescription" : "Vanguard Grenade",
   "level" : 1,
   "tooltipKind" : "thea-activethrowable",
-  "category" : "Throwable",
+  "category" : "throwableItem",
   "itemTags" : ["throwableweapon","avikan"],
   "twoHanded" : false,
 

--- a/items/active/weapons/activethrowables/trinkfrostgrenade/trinkfrostgrenade.activeitem
+++ b/items/active/weapons/activethrowables/trinkfrostgrenade/trinkfrostgrenade.activeitem
@@ -7,7 +7,7 @@
   "shortdescription" : "FROST Canister",
   "level" : 1,
   "tooltipKind" : "thea-activethrowable",
-  "category" : "Throwable",
+  "category" : "throwableItem",
   "itemTags" : ["throwableweapon","trink"],
   "twoHanded" : false,
 


### PR DESCRIPTION
changed 14 items which were using a category of 'Throwable' instead of vanilla's throwableItem category, which has a label override of "Throwable Item". this is so they play a bit nicer with sorting mods.