### PR TITLE
Missing Category in akkimarivaashbarrel.object

### DIFF
--- a/objects/akkimari/containers/akkimarivaashbarrel/akkimarivaashbarrel.object
+++ b/objects/akkimari/containers/akkimarivaashbarrel/akkimarivaashbarrel.object
@@ -4,6 +4,7 @@
   "rarity" : "Common",
   "objectType" : "container",
   "tooltipKind" : "container",
+  "category" : "storage",
   "printable" : false,
   "price" : 100,
   "description" : "A reinforced container built to hold Vaash.",


### PR DESCRIPTION
Added missing category to akkimarivaashbarrel.object. Mainly for compatibility with some inventory mods, but also generally because it didn't have it.